### PR TITLE
add light mode github stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,6 @@
 
 ![My stats!](https://raw.githubusercontent.com/pythoncrazy/github-stats/master/generated/overview.svg#gh-dark-mode-only)
 ![My languages](https://raw.githubusercontent.com/pythoncrazy/github-stats/master/generated/languages.svg#gh-dark-mode-only)
+
+![My stats!](https://raw.githubusercontent.com/pythoncrazy/github-stats/master/generated/overview.svg#gh-light-mode-only)
+![My languages](https://raw.githubusercontent.com/pythoncrazy/github-stats/master/generated/languages.svg#gh-light-mode-only)


### PR DESCRIPTION
light mode users don't see any of the github stats

dark mode POV:
![image](https://github.com/pythoncrazy/pythoncrazy/assets/43558768/f7657495-66b8-44c1-92ec-fa025f427806)

light mode POV:
![image](https://github.com/pythoncrazy/pythoncrazy/assets/43558768/c99ec026-0221-4867-8fad-44021c69e17e)
